### PR TITLE
Utilizing global cluster-set with policies namesapce binding

### DIFF
--- a/data-assets/rs-namespace/deploy/rs-allowlist-policy.yaml
+++ b/data-assets/rs-namespace/deploy/rs-allowlist-policy.yaml
@@ -1,7 +1,8 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: allowlist-policy
+  name: rs-allowlist-policy
+  namespace: policies
 spec:
   remediationAction: enforce
   disabled: false

--- a/data-assets/rs-namespace/deploy/rs-managedclustersetbinding.yaml
+++ b/data-assets/rs-namespace/deploy/rs-managedclustersetbinding.yaml
@@ -1,16 +1,14 @@
-apiVersion: cluster.open-cluster-management.io/v1beta2
-kind: ManagedClusterSet
+apiVersion: v1
+kind: Namespace
 metadata:
-  name: rs-cluster-set
-spec:
-  clusterSelector:
-    selectorType: ExclusiveClusterSetLabel
+  name: policies
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
-  namespace: default
-  name: rs-cluster-set # This must match the ManagedClusterSet name
+  name: global
+  namespace: policies
 spec:
-  clusterSet: rs-cluster-set # Reference to the ManagedClusterSet
+  clusterSet: global
 ---
+

--- a/data-assets/rs-namespace/deploy/rs-policyset.yaml
+++ b/data-assets/rs-namespace/deploy/rs-policyset.yaml
@@ -2,20 +2,20 @@ apiVersion: policy.open-cluster-management.io/v1beta1
 kind: PolicySet
 metadata:
   name: rs-policyset
-  namespace: default
+  namespace: policies
 spec:
   description: Right Sizing Policy Set
   policies:
-    - allowlist-policy
-    - prometheus-rules
+    - rs-allowlist-policy
+    - rs-prometheus-rules
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: rs-policyset-binding
-  namespace: default
+  namespace: policies
 placementRef:
-  name: rs-clusters-placement
+  name: rs-placement
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
@@ -26,19 +26,19 @@ subjects:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  name: rs-clusters-placement
-  namespace: default
+  name: rs-placement
+  namespace: policies
 spec:
+  predicates: []
   tolerations:
     - key: cluster.open-cluster-management.io/unreachable
       operator: Exists
     - key: cluster.open-cluster-management.io/unavailable
       operator: Exists
-  clusterSets:
-    - rs-cluster-set # Referencing the ManagedClusterSet
-  clusterConditions: 
+  clusterConditions:
     - type: ManagedClusterConditionAvailable
       status: "True"
     - type: ManagedClusterConditionHubAccepted
       status: "True"
 ---
+

--- a/data-assets/rs-namespace/deploy/rs-rules-policy.yaml
+++ b/data-assets/rs-namespace/deploy/rs-rules-policy.yaml
@@ -1,7 +1,8 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: prometheus-rules
+  name: rs-prometheus-rules
+  namespace: policies
 spec:
   remediationAction: enforce
   disabled: false


### PR DESCRIPTION
This PR contains changes related to utilizing the `global` cluster-set available by default, as well as namespaces like policies, and removes the hard dependency on creating a separate cluster-set. 