### PR TITLE
Rename object template name for VM rules: acm-vm-right-sizing-rules

### DIFF
--- a/data-assets/rs-virtualization/deploy/rs-vm-rules-policy.yaml
+++ b/data-assets/rs-virtualization/deploy/rs-vm-rules-policy.yaml
@@ -24,7 +24,7 @@ spec:
                 apiVersion: monitoring.coreos.com/v1
                 kind: PrometheusRule
                 metadata:
-                  name: acm-right-sizing-rules
+                  name: acm-vm-right-sizing-rules
                   namespace: openshift-monitoring
                 spec:
                   groups:


### PR DESCRIPTION
Rename object template name for VM rules: acm-vm-right-sizing-rules