### PR TITLE
Add required Notes for the ACM Right Sizing Virtualization Documents

### DIFF
--- a/docs/rs-virtualization/how-to-use-grafana.md
+++ b/docs/rs-virtualization/how-to-use-grafana.md
@@ -22,6 +22,17 @@ This Document described how you can interact with grafana dashboards.
 
     ![Table](../../data-assets/rs-virtualization/images/vm_mem_table.png)
 
+    **Note** : Minimum CPU request is 1 CPU and Minimum Memory request is 1GB.
+
+    * If CPU request is 1 CPU core and utilization is less than 1 core, then we can not say it is Overestimated as minimum CPU request is 1 CPU.
+
+    * If Memory request is 1 GB and utilization is less than 1 GB, then we can not say it is Overestimated as minimum Memory request is 1 GB.
+
+    * CPU/Memory Recommendation is less than CPU/Memory Request then the resources are Overestimated and requires less resources than requested.
+    
+    * CPU/Memory Recommendation is greater than CPU/Memory Request then the resources are Underestimated and requires more resources than requested.
+
+
 6. Click on the Column Header to sort values of particular columns.
 
 7. Click on the Namespace Filter Icon in the Column Header to filter values based on user need.

--- a/docs/rs-virtualization/installation-steps.md
+++ b/docs/rs-virtualization/installation-steps.md
@@ -2,6 +2,8 @@
 
 - Openshift Cluster (tested with 4.15.13+ version)
 - The Advanced Cluster Management operator should be installed on the hub cluster to facilitate cluster administration and data aggregation (tested with 2.10.4+ version).
+- OpenShift Virtualization operator (4.17.6+ version).
+  **Note**: If using OpenShift Virtualization operator (4.17.5 version), VM should be created via template, VM created with instance type is not reporting resource request parameters. [Issue link](https://github.com/kubevirt/kubevirt/pull/14069).
 - [MCO](https://github.com/stolostron/multicluster-observability-operator/) should be installed into the hub cluster with latest version. 
 - `oc` CLI should be installed and configured to interact with Openshift cluster
 


### PR DESCRIPTION
**Note: OpenShift Virtualization operator (4.17.6+ version).**
  - If using OpenShift Virtualization operator (4.17.5 version), VM should be created via template, VM created with instance type is not reporting resource request parameters. [Issue link](https://github.com/kubevirt/kubevirt/pull/14069).

**Note : Minimum CPU request is 1 CPU and Minimum Memory request is 1GB.**

- If CPU request is 1 CPU core and utilization is less than 1 core, then we can not say it is Overestimated as minimum CPU request is 1 CPU.

- If Memory request is 1 GB and utilization is less than 1 GB, then we can not say it is Overestimated as minimum Memory request is 1 GB.

- CPU/Memory Recommendation is less than CPU/Memory Request then the resources are Overestimated and requires less resources than requested.

- CPU/Memory Recommendation is greater than CPU/Memory Request then the resources are Underestimated and requires more resources than requested.