### PR TITLE
[OBSINTA-437] Added value mapping field for small decimal values

### DIFF
--- a/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
+++ b/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
@@ -816,7 +816,7 @@ data:
             "showHeader": true,
             "sortBy": [
               {
-                "desc": true,
+                "desc": false,
                 "displayName": "CPU Utilization %"
               }
             ]
@@ -2065,6 +2065,6 @@ data:
       "timezone": "",
       "title": "ACM Right-Sizing Namespace",
       "uid": "bnqQIPySE",
-      "version": 6,
+      "version": 7,
       "weekStart": ""
     }

--- a/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
+++ b/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
@@ -816,8 +816,8 @@ data:
             "showHeader": true,
             "sortBy": [
               {
-                "desc": false,
-                "displayName": "Namespace"
+                "desc": true,
+                "displayName": "CPU Utilization %"
               }
             ]
           },
@@ -2065,6 +2065,6 @@ data:
       "timezone": "",
       "title": "ACM Right-Sizing Namespace",
       "uid": "bnqQIPySE",
-      "version": 4,
+      "version": 6,
       "weekStart": ""
     }

--- a/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
+++ b/data-assets/rs-namespace/deploy/acm_right_sizing_grafana_dashboard.yaml
@@ -33,7 +33,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 61,
+      "id": 58,
       "links": [],
       "panels": [
         {
@@ -641,6 +641,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -665,6 +691,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -689,6 +741,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -739,7 +817,7 @@ data:
             "sortBy": [
               {
                 "desc": false,
-                "displayName": "CPU Utilization %"
+                "displayName": "Namespace"
               }
             ]
           },
@@ -1504,6 +1582,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -1528,6 +1632,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -1552,6 +1682,32 @@ data:
                   {
                     "id": "custom.align",
                     "value": "left"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "from": 1e-8,
+                          "result": {
+                            "index": 0,
+                            "text": "0.01"
+                          },
+                          "to": 0.00999999
+                        },
+                        "type": "range"
+                      },
+                      {
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "index": 1,
+                            "text": "N/A"
+                          }
+                        },
+                        "type": "special"
+                      }
+                    ]
                   }
                 ]
               },
@@ -1909,6 +2065,6 @@ data:
       "timezone": "",
       "title": "ACM Right-Sizing Namespace",
       "uid": "bnqQIPySE",
-      "version": 12,
+      "version": 4,
       "weekStart": ""
     }


### PR DESCRIPTION
- Added value mapping field so that values between `0.00000001` and `0.00999999` will display as `0.01`.
- The changes applied to `Usage`, `Request` and `Recommendation` columns of both the tables.
- This approach ensures that very small non-zero values are visually represented as 0.01, while true zeros remain unaffected.